### PR TITLE
Added a setter + attr for the scaleTofit

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.1"
     defaultConfig {
         applicationId "com.williamww.silkysignaturedemo"
         minSdkVersion 9
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:25.0.1'
     testCompile 'junit:junit:4.12'
     compile project(':silky-signature')
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.williamww.silkysignaturedemo"
         minSdkVersion 9
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
     testCompile 'junit:junit:4.12'
     compile project(':silky-signature')
 

--- a/app/src/main/java/com/williamww/silkysignaturedemo/MainActivity.java
+++ b/app/src/main/java/com/williamww/silkysignaturedemo/MainActivity.java
@@ -50,6 +50,11 @@ public class MainActivity extends AppCompatActivity {
                 mSaveButton.setEnabled(false);
                 mClearButton.setEnabled(false);
             }
+
+            @Override
+            public void onSignatureLoaded() {
+
+            }
         });
 
         mClearButton = (Button) findViewById(R.id.clear_button);

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.2'
 

--- a/silky-signature/build.gradle
+++ b/silky-signature/build.gradle
@@ -25,12 +25,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
 
@@ -50,7 +50,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:25.0.1'
     testCompile 'junit:junit:4.12'
 }
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'

--- a/silky-signature/src/main/java/com/williamww/silkysignature/views/SignaturePad.java
+++ b/silky-signature/src/main/java/com/williamww/silkysignature/views/SignaturePad.java
@@ -50,6 +50,7 @@ public class SignaturePad extends View {
     private OnSignedListener mOnSignedListener;
     private boolean mClearOnDoubleClick;
     private Matrix.ScaleToFit scaleToFit;
+    private float scaleFactor = 1f;
 
     //Click values
     private long mFirstClick;
@@ -135,12 +136,20 @@ public class SignaturePad extends View {
     }
 
     /**
-     * Set the maximum width of the stroke in pixel.
+     * Set the scale factor of the stroke.
      *
-     * @param maxWidth the width in dp.
+     * @param scaleFactor the scale factor.
      */
-    public void setMaxWidth(float maxWidth) {
-        mMaxWidth = convertDpToPx(maxWidth);
+    public void setScaleFactor(float scaleFactor) {
+       mMaxWidth *= scaleFactor;
+       mMinWidth *= scaleFactor;
+        this.scaleFactor = scaleFactor;
+    }
+
+    public void resetScale(){
+        mMaxWidth /= scaleFactor;
+        mMinWidth /= scaleFactor;
+        scaleFactor = 1f;
     }
 
     /**
@@ -173,6 +182,24 @@ public class SignaturePad extends View {
         }
 
         setIsEmpty(true);
+
+        invalidate();
+    }
+
+    private void silentClear() {
+        mSvgBuilder.clear();
+        mPoints = new ArrayList<>();
+        mLastVelocity = 0;
+        mLastWidth = (mMinWidth + mMaxWidth) / 2;
+
+        if (mSignatureBitmap != null) {
+            mSignatureBitmap = null;
+            ensureSignatureBitmap();
+        }
+
+        if(mOnSignedListener != null){
+            mOnSignedListener.onSignatureLoaded();
+        }
 
         invalidate();
     }
@@ -254,7 +281,7 @@ public class SignaturePad extends View {
     public void setSignatureBitmap(final Bitmap signature) {
         // View was laid out...
         if (ViewCompat.isLaidOut(this)) {
-            clear();
+            silentClear();
             ensureSignatureBitmap();
 
             RectF tempSrc = new RectF();
@@ -599,5 +626,6 @@ public class SignaturePad extends View {
         void onStartSigning();
         void onSigned();
         void onClear();
+        void onSignatureLoaded();
     }
 }

--- a/silky-signature/src/main/java/com/williamww/silkysignature/views/SignaturePad.java
+++ b/silky-signature/src/main/java/com/williamww/silkysignature/views/SignaturePad.java
@@ -49,6 +49,7 @@ public class SignaturePad extends View {
     private float mVelocityFilterWeight;
     private OnSignedListener mOnSignedListener;
     private boolean mClearOnDoubleClick;
+    private Matrix.ScaleToFit scaleToFit;
 
     //Click values
     private long mFirstClick;
@@ -61,6 +62,7 @@ public class SignaturePad extends View {
     private final int DEFAULT_ATTR_PEN_COLOR = Color.BLACK;
     private final float DEFAULT_ATTR_VELOCITY_FILTER_WEIGHT = 0.9f;
     private final boolean DEFAULT_ATTR_CLEAR_ON_DOUBLE_CLICK = false;
+    private final int DEFAULT_ATTR_SCALETOFIT = 0;
 
     private Paint mPaint = new Paint();
     private Bitmap mSignatureBitmap = null;
@@ -81,6 +83,9 @@ public class SignaturePad extends View {
             mPaint.setColor(a.getColor(R.styleable.SignaturePad_penColor, DEFAULT_ATTR_PEN_COLOR));
             mVelocityFilterWeight = a.getFloat(R.styleable.SignaturePad_velocityFilterWeight, DEFAULT_ATTR_VELOCITY_FILTER_WEIGHT);
             mClearOnDoubleClick = a.getBoolean(R.styleable.SignaturePad_clearOnDoubleClick, DEFAULT_ATTR_CLEAR_ON_DOUBLE_CLICK);
+            int scaleToFitType = a.getInt(R.styleable.SignaturePad_scaleToFit, DEFAULT_ATTR_SCALETOFIT);
+            scaleToFit = scaleToFitType == 1? Matrix.ScaleToFit.FILL: Matrix.ScaleToFit.CENTER;
+
         } finally {
             a.recycle();
         }
@@ -145,6 +150,15 @@ public class SignaturePad extends View {
      */
     public void setVelocityFilterWeight(float velocityFilterWeight) {
         mVelocityFilterWeight = velocityFilterWeight;
+    }
+
+    /**
+     * Set the ScaleToFit type.
+     *
+     * @param scaleToFit the scaleToFit when loading a bitmap.
+     */
+    public void setScaleToFit(Matrix.ScaleToFit scaleToFit) {
+        this.scaleToFit = scaleToFit;
     }
 
     public void clear() {
@@ -256,7 +270,7 @@ public class SignaturePad extends View {
             tempDst.set(0, 0, vWidth, vHeight);
 
             Matrix drawMatrix = new Matrix();
-            drawMatrix.setRectToRect(tempSrc, tempDst, Matrix.ScaleToFit.CENTER);
+            drawMatrix.setRectToRect(tempSrc, tempDst, scaleToFit);
 
             Canvas canvas = new Canvas(mSignatureBitmap);
             canvas.drawBitmap(signature, drawMatrix, null);

--- a/silky-signature/src/main/res/values/attrs.xml
+++ b/silky-signature/src/main/res/values/attrs.xml
@@ -6,5 +6,9 @@
         <attr name="penColor" format="color" />
         <attr name="velocityFilterWeight" format="float" />
         <attr name="clearOnDoubleClick" format="boolean"/>
+        <attr name="scaleToFit" format="enum">
+            <enum name="center" value="0"/>
+            <enum name="fill" value="1"/>
+        </attr>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Added a setter + attr for the scaleTofit type use in setSignatureBitmap. If you use Matrix.ScaleToFit.Fill, the signature will be scaled up when the orientation change from portrait to landscape. The signaturePad should(must) have a fix ratio.